### PR TITLE
feat: Add Game collection type to library system

### DIFF
--- a/Emby.Server.Implementations/Library/Resolvers/Games/GameResolver.cs
+++ b/Emby.Server.Implementations/Library/Resolvers/Games/GameResolver.cs
@@ -1,0 +1,157 @@
+#nullable disable
+
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Jellyfin.Data.Enums;
+using Jellyfin.Extensions;
+using MediaBrowser.Controller.Entities.Games;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Resolvers;
+
+namespace Emby.Server.Implementations.Library.Resolvers.Games
+{
+    /// <summary>
+    /// Resolves game files (ROMs) from the filesystem.
+    /// </summary>
+    public class GameResolver : ItemResolver<Game>
+    {
+        /// <summary>
+        /// Mapping of file extensions to platform names.
+        /// </summary>
+        private static readonly Dictionary<string, string> ExtensionToPlatform = new(StringComparer.OrdinalIgnoreCase)
+        {
+            // Nintendo
+            { ".nes", "Nintendo Entertainment System" },
+            { ".sfc", "Super Nintendo" },
+            { ".smc", "Super Nintendo" },
+            { ".n64", "Nintendo 64" },
+            { ".z64", "Nintendo 64" },
+            { ".v64", "Nintendo 64" },
+            { ".nds", "Nintendo DS" },
+            { ".3ds", "Nintendo 3DS" },
+            { ".gb", "Game Boy" },
+            { ".gbc", "Game Boy Color" },
+            { ".gba", "Game Boy Advance" },
+            { ".gcm", "GameCube" },
+            { ".gcz", "GameCube" },
+            { ".wbfs", "Wii" },
+            { ".wad", "Wii" },
+
+            // Sega
+            { ".sms", "Sega Master System" },
+            { ".gg", "Sega Game Gear" },
+            { ".md", "Sega Genesis" },
+            { ".gen", "Sega Genesis" },
+            { ".32x", "Sega 32X" },
+            { ".cdi", "Sega Dreamcast" },
+            { ".gdi", "Sega Dreamcast" },
+
+            // Sony
+            { ".pbp", "PlayStation Portable" },
+            { ".pkg", "PlayStation" },
+
+            // Atari
+            { ".a26", "Atari 2600" },
+            { ".a78", "Atari 7800" },
+            { ".lnx", "Atari Lynx" },
+            { ".jag", "Atari Jaguar" },
+
+            // Other
+            { ".pce", "TurboGrafx-16" },
+            { ".ngp", "Neo Geo Pocket" },
+            { ".ngc", "Neo Geo Pocket Color" },
+            { ".ws", "WonderSwan" },
+            { ".wsc", "WonderSwan Color" },
+
+            // Disc images (multi-platform)
+            { ".iso", "Disc Image" },
+            { ".bin", "Disc Image" },
+            { ".cue", "Disc Image" },
+            { ".chd", "Compressed Disc Image" },
+
+            // Archives (ROMs inside)
+            { ".zip", "Archive" },
+            { ".7z", "Archive" }
+        };
+
+        /// <inheritdoc />
+        protected override Game Resolve(ItemResolveArgs args)
+        {
+            var collectionType = args.GetCollectionType();
+
+            // Only process items that are in a games collection
+            if (collectionType != CollectionType.games)
+            {
+                return null;
+            }
+
+            // Skip directories for now - individual files only
+            if (args.IsDirectory)
+            {
+                return null;
+            }
+
+            var extension = Path.GetExtension(args.Path.AsSpan());
+
+            if (extension.IsEmpty)
+            {
+                return null;
+            }
+
+            var extensionString = extension.ToString();
+            if (!ExtensionToPlatform.TryGetValue(extensionString, out var platform))
+            {
+                return null;
+            }
+
+            var fileName = Path.GetFileNameWithoutExtension(args.Path);
+            var gameName = CleanGameName(fileName);
+
+            return new Game
+            {
+                Path = args.Path,
+                RomPath = args.Path,
+                Name = gameName,
+                Platform = platform,
+                IsInMixedFolder = true
+            };
+        }
+
+        /// <summary>
+        /// Cleans up the game name by removing common ROM naming conventions.
+        /// Handles No-Intro and GoodTools naming patterns.
+        /// </summary>
+        /// <param name="fileName">The filename without extension.</param>
+        /// <returns>A cleaned game name.</returns>
+        private static string CleanGameName(string fileName)
+        {
+            if (string.IsNullOrEmpty(fileName))
+            {
+                return string.Empty;
+            }
+
+            var name = fileName;
+
+            // Remove content in parentheses (region codes, versions, etc.)
+            // e.g., "Super Mario 64 (USA)" -> "Super Mario 64"
+            var parenIndex = name.IndexOf('(', StringComparison.Ordinal);
+            if (parenIndex > 0)
+            {
+                name = name[..parenIndex];
+            }
+
+            // Remove content in square brackets (GoodTools codes)
+            // e.g., "Super Mario Bros [!]" -> "Super Mario Bros"
+            var bracketIndex = name.IndexOf('[', StringComparison.Ordinal);
+            if (bracketIndex > 0)
+            {
+                name = name[..bracketIndex];
+            }
+
+            return name.Trim();
+        }
+    }
+}

--- a/Jellyfin.Data/Enums/CollectionType.cs
+++ b/Jellyfin.Data/Enums/CollectionType.cs
@@ -74,6 +74,11 @@ public enum CollectionType
     folders = 12,
 
     /// <summary>
+    /// Games collection.
+    /// </summary>
+    games = 13,
+
+    /// <summary>
     /// Tv show series collection.
     /// </summary>
     [OpenApiIgnoreEnum]

--- a/Jellyfin.Data/Enums/MediaType.cs
+++ b/Jellyfin.Data/Enums/MediaType.cs
@@ -28,5 +28,10 @@ public enum MediaType
     /// <summary>
     /// Book media.
     /// </summary>
-    Book = 4
+    Book = 4,
+
+    /// <summary>
+    /// Game media (ROMs, game files).
+    /// </summary>
+    Game = 5
 }

--- a/Jellyfin.Data/Enums/UnratedItem.cs
+++ b/Jellyfin.Data/Enums/UnratedItem.cs
@@ -48,6 +48,11 @@ namespace Jellyfin.Data.Enums
         /// <summary>
         /// Another type, not covered by the other fields.
         /// </summary>
-        Other = 8
+        Other = 8,
+
+        /// <summary>
+        /// A game.
+        /// </summary>
+        Game = 9
     }
 }

--- a/MediaBrowser.Controller/Entities/Games/Game.cs
+++ b/MediaBrowser.Controller/Entities/Games/Game.cs
@@ -1,0 +1,70 @@
+#nullable disable
+
+#pragma warning disable CS1591
+
+using System;
+using System.Text.Json.Serialization;
+using Jellyfin.Data.Enums;
+using MediaBrowser.Controller.Providers;
+
+namespace MediaBrowser.Controller.Entities.Games
+{
+    /// <summary>
+    /// Represents a game (ROM or game file) in the library.
+    /// </summary>
+    [Common.RequiresSourceSerialisation]
+    public class Game : BaseItem, IHasLookupInfo<GameInfo>
+    {
+        /// <summary>
+        /// Gets or sets the platform/console for this game (e.g., "Nintendo 64", "PlayStation", "GameBoy Advance").
+        /// </summary>
+        [JsonIgnore]
+        public string Platform { get; set; }
+
+        /// <summary>
+        /// Gets or sets the emulator configuration identifier to use for launching this game.
+        /// </summary>
+        [JsonIgnore]
+        public string EmulatorId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to the ROM or game file.
+        /// </summary>
+        [JsonIgnore]
+        public string RomPath { get; set; }
+
+        /// <inheritdoc />
+        [JsonIgnore]
+        public override MediaType MediaType => MediaType.Game;
+
+        /// <inheritdoc />
+        public override bool SupportsPlayedStatus => true;
+
+        /// <inheritdoc />
+        [JsonIgnore]
+        public override bool SupportsPeople => false;
+
+        /// <inheritdoc />
+        public override bool CanDownload()
+        {
+            return IsFileProtocol;
+        }
+
+        /// <inheritdoc />
+        public override UnratedItem GetBlockUnratedType()
+        {
+            return UnratedItem.Game;
+        }
+
+        /// <summary>
+        /// Gets the lookup info for metadata providers.
+        /// </summary>
+        /// <returns>The game lookup info.</returns>
+        public GameInfo GetLookupInfo()
+        {
+            var info = GetItemLookupInfo<GameInfo>();
+            info.Platform = Platform;
+            return info;
+        }
+    }
+}

--- a/MediaBrowser.Controller/Providers/GameInfo.cs
+++ b/MediaBrowser.Controller/Providers/GameInfo.cs
@@ -1,0 +1,17 @@
+#nullable disable
+
+#pragma warning disable CS1591
+
+namespace MediaBrowser.Controller.Providers
+{
+    /// <summary>
+    /// Represents lookup information for a game, used by metadata providers.
+    /// </summary>
+    public class GameInfo : ItemLookupInfo
+    {
+        /// <summary>
+        /// Gets or sets the platform/console for this game (e.g., "Nintendo 64", "PlayStation").
+        /// </summary>
+        public string Platform { get; set; }
+    }
+}

--- a/MediaBrowser.Model/Entities/CollectionTypeOptions.cs
+++ b/MediaBrowser.Model/Entities/CollectionTypeOptions.cs
@@ -45,5 +45,10 @@ public enum CollectionTypeOptions
     /// <summary>
     /// Mixed Movies and TV Shows.
     /// </summary>
-    mixed = 7
+    mixed = 7,
+
+    /// <summary>
+    /// Games (ROMs and game files).
+    /// </summary>
+    games = 8
 }


### PR DESCRIPTION
Add support for a new "Games" library type that allows Jellyfin to recognize and manage game libraries (ROMs) separate from other media.

Changes:
- Add 'games' to CollectionType and CollectionTypeOptions enums
- Add 'Game' to MediaType and UnratedItem enums
- Create Game entity class with platform and emulator config support
- Create GameInfo lookup class for metadata providers
- Create GameResolver that detects ROM files by extension and extracts basic metadata from filenames (No-Intro/GoodTools naming support)

Supported ROM formats include: NES, SNES, N64, GameBoy, GBA, NDS, 3DS, GameCube, Wii, Sega Genesis, Dreamcast, PlayStation, and disc images.

Closes #3

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
