### PR TITLE
feat: Add Games API controller

### DIFF
--- a/Jellyfin.Api/Controllers/GamesController.cs
+++ b/Jellyfin.Api/Controllers/GamesController.cs
@@ -1,0 +1,235 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using Jellyfin.Api.Extensions;
+using Jellyfin.Api.Helpers;
+using Jellyfin.Api.ModelBinders;
+using Jellyfin.Data.Enums;
+using Jellyfin.Extensions;
+using MediaBrowser.Controller.Dto;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Games;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Querying;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Api.Controllers;
+
+/// <summary>
+/// Games controller for managing game libraries and launching games.
+/// </summary>
+[Route("[controller]")]
+[Authorize]
+public class GamesController : BaseJellyfinApiController
+{
+    private readonly IUserManager _userManager;
+    private readonly ILibraryManager _libraryManager;
+    private readonly IDtoService _dtoService;
+    private readonly ILogger<GamesController> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GamesController"/> class.
+    /// </summary>
+    /// <param name="userManager">Instance of the <see cref="IUserManager"/> interface.</param>
+    /// <param name="libraryManager">Instance of the <see cref="ILibraryManager"/> interface.</param>
+    /// <param name="dtoService">Instance of the <see cref="IDtoService"/> interface.</param>
+    /// <param name="logger">Instance of the <see cref="ILogger{GamesController}"/> interface.</param>
+    public GamesController(
+        IUserManager userManager,
+        ILibraryManager libraryManager,
+        IDtoService dtoService,
+        ILogger<GamesController> logger)
+    {
+        _userManager = userManager;
+        _libraryManager = libraryManager;
+        _dtoService = dtoService;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Gets all games.
+    /// </summary>
+    /// <param name="userId">Optional. Filter by user id.</param>
+    /// <param name="parentId">Optional. Specify a parent folder to search within.</param>
+    /// <param name="startIndex">Optional. The record index to start at.</param>
+    /// <param name="limit">Optional. The maximum number of records to return.</param>
+    /// <param name="searchTerm">Optional. Filter based on a search term.</param>
+    /// <param name="sortBy">Optional. Specify one or more sort orders.</param>
+    /// <param name="sortOrder">Sort Order - Ascending or Descending.</param>
+    /// <param name="fields">Optional. Specify additional fields of information to return.</param>
+    /// <param name="enableImages">Optional. Include image information in output.</param>
+    /// <param name="enableTotalRecordCount">Optional. Include total record count.</param>
+    /// <response code="200">Games returned.</response>
+    /// <returns>An <see cref="QueryResult{BaseItemDto}"/> with the games.</returns>
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public ActionResult<QueryResult<BaseItemDto>> GetGames(
+        [FromQuery] Guid? userId,
+        [FromQuery] Guid? parentId,
+        [FromQuery] int? startIndex,
+        [FromQuery] int? limit,
+        [FromQuery] string? searchTerm,
+        [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] ItemSortBy[] sortBy,
+        [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] SortOrder[] sortOrder,
+        [FromQuery, ModelBinder(typeof(CommaDelimitedCollectionModelBinder))] ItemFields[] fields,
+        [FromQuery] bool? enableImages,
+        [FromQuery] bool enableTotalRecordCount = true)
+    {
+        var user = userId.HasValue && !userId.Value.IsEmpty()
+            ? _userManager.GetUserById(userId.Value)
+            : null;
+
+        var dtoOptions = new DtoOptions { Fields = fields }
+            .AddClientFields(User);
+
+        if (enableImages.HasValue)
+        {
+            dtoOptions.EnableImages = enableImages.Value;
+        }
+
+        var query = new InternalItemsQuery(user)
+        {
+            MediaTypes = new[] { MediaType.Game },
+            StartIndex = startIndex,
+            Limit = limit,
+            SearchTerm = searchTerm,
+            OrderBy = RequestHelpers.GetOrderBy(sortBy, sortOrder),
+            DtoOptions = dtoOptions,
+            Recursive = true,
+            EnableTotalRecordCount = enableTotalRecordCount
+        };
+
+        if (parentId.HasValue && !parentId.Value.IsEmpty())
+        {
+            var parentItem = _libraryManager.GetItemById(parentId.Value);
+            if (parentItem is not null)
+            {
+                query.AncestorIds = new[] { parentId.Value };
+            }
+        }
+
+        var result = _libraryManager.GetItemsResult(query);
+
+        var dtos = result.Items.Select(i => _dtoService.GetBaseItemDto(i, dtoOptions, user));
+
+        return new QueryResult<BaseItemDto>(
+            startIndex,
+            result.TotalRecordCount,
+            dtos.ToArray());
+    }
+
+    /// <summary>
+    /// Gets a game by id.
+    /// </summary>
+    /// <param name="itemId">The item id.</param>
+    /// <param name="userId">Optional. Filter by user id.</param>
+    /// <response code="200">Game returned.</response>
+    /// <response code="404">Game not found.</response>
+    /// <returns>An <see cref="BaseItemDto"/> with the game.</returns>
+    [HttpGet("{itemId}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public ActionResult<BaseItemDto> GetGame(
+        [FromRoute, Required] Guid itemId,
+        [FromQuery] Guid? userId)
+    {
+        var user = userId.HasValue && !userId.Value.IsEmpty()
+            ? _userManager.GetUserById(userId.Value)
+            : null;
+
+        var item = _libraryManager.GetItemById(itemId);
+
+        if (item is not Game game)
+        {
+            return NotFound();
+        }
+
+        var dtoOptions = new DtoOptions().AddClientFields(User);
+
+        return _dtoService.GetBaseItemDto(game, dtoOptions, user);
+    }
+
+    /// <summary>
+    /// Launches a game. Returns launch information for the game streaming client.
+    /// </summary>
+    /// <remarks>
+    /// This is a stub endpoint for Moonlight/Sunshine integration.
+    /// In the future, this will trigger the game launch on the configured streaming server.
+    /// </remarks>
+    /// <param name="itemId">The item id of the game to launch.</param>
+    /// <response code="200">Game launch info returned.</response>
+    /// <response code="404">Game not found.</response>
+    /// <returns>Launch information for the game.</returns>
+    [HttpPost("{itemId}/Launch")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public ActionResult<GameLaunchInfo> LaunchGame([FromRoute, Required] Guid itemId)
+    {
+        var item = _libraryManager.GetItemById(itemId);
+
+        if (item is not Game game)
+        {
+            return NotFound();
+        }
+
+        _logger.LogInformation("Game launch requested: {GameName} ({GameId})", game.Name, game.Id);
+
+        // TODO: Integrate with Sunshine/Moonlight to actually launch the game
+        // For now, return the information needed by a client to initiate streaming
+        return new GameLaunchInfo
+        {
+            GameId = game.Id,
+            GameName = game.Name,
+            Platform = game.Platform,
+            RomPath = game.RomPath ?? game.Path,
+            EmulatorId = game.EmulatorId,
+            Status = "ready",
+            Message = "Game launch endpoint ready. Moonlight/Sunshine integration pending."
+        };
+    }
+}
+
+/// <summary>
+/// Information returned when launching a game.
+/// </summary>
+public class GameLaunchInfo
+{
+    /// <summary>
+    /// Gets or sets the game's unique identifier.
+    /// </summary>
+    public Guid GameId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the game's name.
+    /// </summary>
+    public string? GameName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the platform/console for the game.
+    /// </summary>
+    public string? Platform { get; set; }
+
+    /// <summary>
+    /// Gets or sets the path to the ROM or game file.
+    /// </summary>
+    public string? RomPath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the emulator configuration to use.
+    /// </summary>
+    public string? EmulatorId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the launch status.
+    /// </summary>
+    public string? Status { get; set; }
+
+    /// <summary>
+    /// Gets or sets any message about the launch.
+    /// </summary>
+    public string? Message { get; set; }
+}

--- a/Jellyfin.Data/Enums/BaseItemKind.cs
+++ b/Jellyfin.Data/Enums/BaseItemKind.cs
@@ -64,6 +64,11 @@ namespace Jellyfin.Data.Enums
         Folder,
 
         /// <summary>
+        /// Item is game.
+        /// </summary>
+        Game,
+
+        /// <summary>
         /// Item is genre.
         /// </summary>
         Genre,


### PR DESCRIPTION
Add dedicated API controller for game library operations:
- GET /Games - List all games with filtering and pagination
- GET /Games/{itemId} - Get specific game details
- POST /Games/{itemId}/Launch - Stub for game launching (Moonlight integration)

Also adds Game to BaseItemKind enum for proper item type identification.

The launch endpoint returns GameLaunchInfo with game details needed for streaming clients. Full Moonlight/Sunshine integration will be added in a future update.

Closes #5

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our documentation.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
