### PR TITLE
Add GamePlatform to API responses

### DIFF
--- a/Emby.Server.Implementations/Dto/DtoService.cs
+++ b/Emby.Server.Implementations/Dto/DtoService.cs
@@ -530,6 +530,11 @@ namespace Emby.Server.Implementations.Dto
             dto.SeriesName = item.SeriesName;
         }
 
+        private static void SetGameProperties(BaseItemDto dto, MediaBrowser.Controller.Entities.Games.Game item)
+        {
+            dto.GamePlatform = item.Platform;
+        }
+
         private static void SetPhotoProperties(BaseItemDto dto, Photo item)
         {
             dto.CameraMake = item.CameraMake;
@@ -1301,6 +1306,11 @@ namespace Emby.Server.Implementations.Dto
             if (item is Book book)
             {
                 SetBookProperties(dto, book);
+            }
+
+            if (item is MediaBrowser.Controller.Entities.Games.Game game)
+            {
+                SetGameProperties(dto, game);
             }
 
             if (options.ContainsField(ItemFields.ProductionLocations))

--- a/MediaBrowser.Model/Dto/BaseItemDto.cs
+++ b/MediaBrowser.Model/Dto/BaseItemDto.cs
@@ -341,6 +341,12 @@ namespace MediaBrowser.Model.Dto
         public string SeriesName { get; set; }
 
         /// <summary>
+        /// Gets or sets the game platform/console (e.g., "Nintendo 64", "PlayStation").
+        /// </summary>
+        /// <value>The game platform.</value>
+        public string GamePlatform { get; set; }
+
+        /// <summary>
         /// Gets or sets the series id.
         /// </summary>
         /// <value>The series id.</value>


### PR DESCRIPTION
## Summary

Adds GamePlatform property to BaseItemDto so the web UI can display the platform/console for each game.

### Changes

- Add `GamePlatform` property to `BaseItemDto`
- Add `SetGameProperties` method in `DtoService` to populate GamePlatform
- Game items now include platform info in API responses

### API Response Example

Game items will now include:
```json
{
  "Name": "Super Mario 64",
  "Type": "Game",
  "GamePlatform": "Nintendo 64"
}
```

## Test Plan
- [ ] GET /Games returns items with GamePlatform field populated
- [ ] Web UI can display platform info for games

Closes #8