### PR TITLE
fix: Initialize non-nullable properties in config classes

### DIFF
--- a/MediaBrowser.Model/Configuration/EmulatorProfile.cs
+++ b/MediaBrowser.Model/Configuration/EmulatorProfile.cs
@@ -15,8 +15,12 @@ namespace MediaBrowser.Model.Configuration
         public EmulatorProfile()
         {
             Id = Guid.NewGuid().ToString("N");
+            Name = string.Empty;
             Platforms = Array.Empty<string>();
             FileExtensions = Array.Empty<string>();
+            ExecutablePath = string.Empty;
+            CommandLineArgs = string.Empty;
+            SunshineAppName = string.Empty;
         }
 
         /// <summary>
@@ -32,13 +36,13 @@ namespace MediaBrowser.Model.Configuration
         /// <summary>
         /// Gets or sets the platforms/consoles this emulator supports.
         /// </summary>
-        /// <example>["Nintendo 64", "PlayStation"]</example>
+        /// <example>["Nintendo 64", "PlayStation"].</example>
         public string[] Platforms { get; set; }
 
         /// <summary>
         /// Gets or sets the file extensions this emulator handles.
         /// </summary>
-        /// <example>[".n64", ".z64", ".iso"]</example>
+        /// <example>[".n64", ".z64", ".iso"].</example>
         public string[] FileExtensions { get; set; }
 
         /// <summary>
@@ -50,7 +54,7 @@ namespace MediaBrowser.Model.Configuration
         /// Gets or sets the command line arguments template.
         /// Use {rom} as placeholder for the ROM path.
         /// </summary>
-        /// <example>-L /path/to/core.so "{rom}"</example>
+        /// <example>-L /path/to/core.so "{rom}".</example>
         public string CommandLineArgs { get; set; }
 
         /// <summary>

--- a/MediaBrowser.Model/Configuration/GamingOptions.cs
+++ b/MediaBrowser.Model/Configuration/GamingOptions.cs
@@ -15,6 +15,8 @@ namespace MediaBrowser.Model.Configuration
         public GamingOptions()
         {
             EmulatorProfiles = Array.Empty<EmulatorProfile>();
+            SunshineHost = string.Empty;
+            DefaultEmulatorProfileId = string.Empty;
         }
 
         /// <summary>
@@ -30,7 +32,7 @@ namespace MediaBrowser.Model.Configuration
         /// <summary>
         /// Gets or sets the Sunshine server host for game streaming.
         /// </summary>
-        /// <example>192.168.1.100</example>
+        /// <example>192.168.1.100.</example>
         public string SunshineHost { get; set; }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Fix build errors (CS8618) by initializing non-nullable string properties in constructors.

### Changes

**EmulatorProfile.cs:**
- Initialize `Name`, `ExecutablePath`, `CommandLineArgs`, `SunshineAppName` to `string.Empty`

**GamingOptions.cs:**
- Initialize `SunshineHost`, `DefaultEmulatorProfileId` to `string.Empty`

Also fixes SA1629 documentation warnings by adding periods to example tags.

## Build Verification

This fixes the following errors:
```
CS8618: Non-nullable property must contain a non-null value when exiting constructor
SA1629: Documentation text should end with a period
```